### PR TITLE
Update maveninstall to point to 3.6.3

### DIFF
--- a/scripts/linux/installMaven.sh
+++ b/scripts/linux/installMaven.sh
@@ -11,7 +11,7 @@ rm -f apache-maven-$MAVEN_VERSION-bin.zip
 echo export PATH="\$PATH:~/apache-maven-$MAVEN_VERSION/bin" >> ~/.bashrc
 exit
 }
-export MAVEN_VERSION=3.6.1
+export MAVEN_VERSION=3.6.3
 echo -e '\n'Please check the corresponding Maven version from:
 echo https://maven.apache.org/download.cgi
 echo currently the config file has the following versions:


### PR DESCRIPTION
Update maven install script to bump default version to 3.6.3 as 3.6.1 is no longer available for download