### PR TITLE
Source bashrc after updating it

### DIFF
--- a/scripts/linux/installMaven.sh
+++ b/scripts/linux/installMaven.sh
@@ -9,6 +9,7 @@ mv apache-maven-$MAVEN_VERSION ~
 
 rm -f apache-maven-$MAVEN_VERSION-bin.zip
 echo export PATH="\$PATH:~/apache-maven-$MAVEN_VERSION/bin" >> ~/.bashrc
+source ~/.bashrc
 exit
 }
 export MAVEN_VERSION=3.6.1


### PR DESCRIPTION
This would only work after a reboot as we don't source the bashrc file once updating it to include the maven path.